### PR TITLE
feat: Member ↔ Lecture N:M 관계 설계 및 MemberLecture 엔티티 생성

### DIFF
--- a/backend/src/main/java/com/ktnu/AiLectureSummary/config/JpaConfig.java
+++ b/backend/src/main/java/com/ktnu/AiLectureSummary/config/JpaConfig.java
@@ -1,0 +1,10 @@
+package com.ktnu.AiLectureSummary.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing // JPA 엔티티의 생성일, 수정일을 자동으로 기록해주는 Auditing 기능 활성화
+public class JpaConfig {
+    // 이 설정으로 @CreatedDate, @LastModifiedDate 어노테이션이 동작하게 됨
+}

--- a/backend/src/main/java/com/ktnu/AiLectureSummary/domain/Lecture.java
+++ b/backend/src/main/java/com/ktnu/AiLectureSummary/domain/Lecture.java
@@ -1,35 +1,34 @@
 package com.ktnu.AiLectureSummary.domain;
 
+import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
+import java.util.List;
+import java.util.ArrayList;
 
 /**
- * Member 1 : N Lecture (Lecture가 Member를 참조하고, Member는 여러 Lecture를 가질 수 있음)
- * 강의 정보를 나타내는 엔티티 클래스
- * - name: 강의명
- * - summary: 요약된 내용
- * -
+ *   강의 정보를 나타내는 엔티티 클래스
  */
 
-//@Entity
+@Entity
 @Getter
 @Setter
 public class Lecture {
 
-//    @Id
-//    @GeneratedValue(strategy = GenerationType.IDENTITY)
-//    private Long id;
-//
-//    /**
-//     * 강의 요약을 작성한 회원
-//     * - 여러 강의 요약이 하나의 회원에 연결
-//     */
-//    private Member member;
-//
-//
-//    private String name;
-//
-//    private  String summary;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+
+    @Column(nullable = false)
+    private  String aisummary;
+
+    @OneToMany(mappedBy = "lecture", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<MemberLecture> memberLectures = new ArrayList<>();
 
 
 }

--- a/backend/src/main/java/com/ktnu/AiLectureSummary/domain/MemberLecture.java
+++ b/backend/src/main/java/com/ktnu/AiLectureSummary/domain/MemberLecture.java
@@ -1,0 +1,45 @@
+package com.ktnu.AiLectureSummary.domain;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import jakarta.persistence.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+/**
+ * MemberLecture 엔티티 클래스
+ * - 회원이 특정 강의를 요약한 이력을 나타냄
+ * - Member ↔ Lecture 간 N:M 관계를 중간 테이블로 표현
+ */
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+public class MemberLecture {
+
+    /**
+     * 고유 ID (Primary Key)
+     * - 자동 증가 전략 사용
+     */
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // Member 연관 관계
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id") // 외래 키 컬럼 이름을 'member_id'로 지정하여 Member의 PK(id)를 참조    private Member member;
+    private Member member;
+
+    // Lecture 연관 관계
+    @ManyToOne (fetch = FetchType.LAZY)
+    @JoinColumn(name = "lecture_id")
+    private Lecture lecture;
+
+    @CreatedDate
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private LocalDateTime enrolledAt;
+
+    // 사용자 개별 메모 저장용 (TEXT 타입)
+    @Column(nullable = true,columnDefinition = "TEXT")
+    private String personalNote;
+
+}

--- a/backend/src/main/java/com/ktnu/AiLectureSummary/exception/MemberNotFoundException.java
+++ b/backend/src/main/java/com/ktnu/AiLectureSummary/exception/MemberNotFoundException.java
@@ -3,6 +3,6 @@ package com.ktnu.AiLectureSummary.exception;
 
 public class MemberNotFoundException extends RuntimeException{
     public MemberNotFoundException(String message){
-        super();
+        super(message);
     }
 }


### PR DESCRIPTION
feat: MemberLecture 중간 테이블 도입으로 Member ↔ Lecture N:M 매핑
- 연관관계 매핑 및 주석 정리
- personalNote, enrolledAt 필드 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced automatic tracking of creation and modification timestamps for key data records.
  - Added support for associating multiple members with lectures through a new relationship entity, enabling richer lecture summary management.
  - Enabled members to add personal notes to their lecture summaries.

- **Improvements**
  - Enhanced error messages for missing member scenarios, providing clearer feedback to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->