### PR TITLE
feat: MemberLectureService

### DIFF
--- a/backend/src/main/java/com/ktnu/AiLectureSummary/domain/MemberLecture.java
+++ b/backend/src/main/java/com/ktnu/AiLectureSummary/domain/MemberLecture.java
@@ -2,6 +2,7 @@ package com.ktnu.AiLectureSummary.domain;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import jakarta.persistence.*;
+import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -11,14 +12,18 @@ import java.time.LocalDateTime;
  * MemberLecture 엔티티 클래스
  * - 회원이 특정 강의를 요약한 이력을 나타냄
  * - Member ↔ Lecture 간 N:M 관계를 중간 테이블로 표현
- *
+ * <p>
  * MemberLecture는 특정 사용자와 강의 간의 관계이므로,
- * 	•	“내가 본 강의의 메모”
- * 	•	“내가 요약 요청한 날짜”
- * 	•	“내가 직접 수정한 요약”
+ * •	“내가 본 강의의 메모”
+ * •	“내가 요약 요청한 날짜”
+ * •	“내가 직접 수정한 요약”
  */
 @Entity
 @EntityListeners(AuditingEntityListener.class)
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MemberLecture {
 
     /**
@@ -35,7 +40,7 @@ public class MemberLecture {
     private Member member;
 
     // Lecture 연관 관계
-    @ManyToOne (fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "lecture_id")
     private Lecture lecture;
 
@@ -44,7 +49,7 @@ public class MemberLecture {
     private LocalDateTime enrolledAt;
 
     // 사용자 개별 메모 저장용 (TEXT 타입)
-    @Column(nullable = true,columnDefinition = "TEXT")
+    @Column(nullable = true, columnDefinition = "TEXT")
     private String personalNote;
 
 }

--- a/backend/src/main/java/com/ktnu/AiLectureSummary/dto/member/MemberResponse.java
+++ b/backend/src/main/java/com/ktnu/AiLectureSummary/dto/member/MemberResponse.java
@@ -4,14 +4,11 @@ import com.ktnu.AiLectureSummary.domain.Member;
 import lombok.Getter;
 
 @Getter
-//@AllArgsConstructor
 public class MemberResponse {
-    private Long id;
     private String email;
     private String username;
 
     public MemberResponse(Member member){
-        this.id = member.getId();
         this.email = member.getEmail();
         this.username = member.getUsername();
     }

--- a/backend/src/main/java/com/ktnu/AiLectureSummary/security/principal/CustomUserDetails.java
+++ b/backend/src/main/java/com/ktnu/AiLectureSummary/security/principal/CustomUserDetails.java
@@ -13,7 +13,7 @@ import java.util.Collections;
 @RequiredArgsConstructor
 @Getter
 public class CustomUserDetails implements UserDetails {
-
+    // Member로 쓰면 편리하지만, 직렬화나 세션/캐시 저장시 무거울수 있고, 보안성이 낮음
     private final Member member;
 
 
@@ -30,6 +30,10 @@ public class CustomUserDetails implements UserDetails {
     @Override
     public String getUsername() {
         return member.getEmail(); // 로그인 ID 기준 (email)
+    }
+
+    public Long getId(){
+        return member.getId();
     }
 
     @Override

--- a/backend/src/main/java/com/ktnu/AiLectureSummary/service/MemberLectureService.java
+++ b/backend/src/main/java/com/ktnu/AiLectureSummary/service/MemberLectureService.java
@@ -1,7 +1,11 @@
 package com.ktnu.AiLectureSummary.service;
 
 
+import com.ktnu.AiLectureSummary.domain.Lecture;
+import com.ktnu.AiLectureSummary.domain.Member;
+import com.ktnu.AiLectureSummary.domain.MemberLecture;
 import com.ktnu.AiLectureSummary.repository.MemberLectureRepository;
+import com.ktnu.AiLectureSummary.security.principal.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -9,5 +13,17 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class MemberLectureService {
     private final MemberLectureRepository memberLectureRepository;
+    private final MemberService memberService;
+
+    public void save(CustomUserDetails user, Lecture lecture) {
+        Member member = memberService.findById(user.getId());
+        memberLectureRepository.save(
+                MemberLecture.builder()
+                        .member(member)
+                        .lecture(lecture)
+                        .build()
+        );
+    }
+
 
 }

--- a/backend/src/main/java/com/ktnu/AiLectureSummary/service/MemberService.java
+++ b/backend/src/main/java/com/ktnu/AiLectureSummary/service/MemberService.java
@@ -1,6 +1,5 @@
 package com.ktnu.AiLectureSummary.service;
 
-import com.ktnu.AiLectureSummary.security.jwt.JwtTokenProvider;
 import com.ktnu.AiLectureSummary.domain.Member;
 import com.ktnu.AiLectureSummary.dto.member.LoginResponse;
 import com.ktnu.AiLectureSummary.dto.member.MemberLoginRequest;
@@ -10,11 +9,11 @@ import com.ktnu.AiLectureSummary.exception.DuplicateLoginIdException;
 import com.ktnu.AiLectureSummary.exception.InvalidPasswordException;
 import com.ktnu.AiLectureSummary.exception.MemberNotFoundException;
 import com.ktnu.AiLectureSummary.repository.MemberRepository;
-import jakarta.transaction.Transactional;
+import com.ktnu.AiLectureSummary.security.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
-
+import org.springframework.transaction.annotation.Transactional;
 
 
 @Service
@@ -72,4 +71,14 @@ public class MemberService {
 
     // /me -> Controller 에서 처리
 
+    /**
+     * id를 이용하여 DB에서  회원 조회, 존재 하지 않으면 MemberNotFoundException 발생
+     * @param id 조회할 회원의 고유 ID
+     * @return 해당 ID에 대응하는 Member 객체
+     * @throws MemberNotFoundException 존재하지 않는 ID일 경우 발생
+     */
+    public Member findById(long id) {
+        return memberRepository.findById(id)
+                .orElseThrow(() -> new MemberNotFoundException("해당 ID의 회원이 존재하지 않습니다."));
+    }
 }


### PR DESCRIPTION
feat: 사용자-강의 소유 관계 저장 로직 및 로그인 응답 개선

- MemberLectureService 구현 및 Member와 Lecture 간 소유 관계 저장 처리
- processVideoUpload 메서드에 @Transactional 적용으로 원자성 보장
- 로그인 응답에서 member.id 제거로 MemberResponse DTO 구조 간소화

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to associate users with lectures when uploading a video, allowing ownership relationships to be recorded.
  - Introduced support for saving and managing member-lecture relationships.

- **Improvements**
  - Enhanced user detail handling with a new method to retrieve user IDs.
  - Improved service methods for member retrieval by ID.
  - Applied transactional integrity to the video upload process.

- **Bug Fixes**
  - Removed unnecessary user ID exposure in member response data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->