### PR TITLE
feat: 내 강의 대시보드 기능 구현

### DIFF
--- a/backend/src/main/java/com/ktnu/AiLectureSummary/controller/MemberLectureController.java
+++ b/backend/src/main/java/com/ktnu/AiLectureSummary/controller/MemberLectureController.java
@@ -1,14 +1,38 @@
 package com.ktnu.AiLectureSummary.controller;
 
 
+import com.ktnu.AiLectureSummary.dto.lecture.LectureListItemResponse;
+import com.ktnu.AiLectureSummary.dto.lecture.LectureResponse;
+import com.ktnu.AiLectureSummary.security.principal.CustomUserDetails;
 import com.ktnu.AiLectureSummary.service.MemberLectureService;
+import com.ktnu.AiLectureSummary.service.MemberService;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api/member-lectures")
 public class MemberLectureController {
+
     private final MemberLectureService memberLectureService;
 
-
+    @GetMapping("/dashboard")
+    @Operation(
+            summary = "내 강의 목록 조회",
+            description = "로그인한 사용자가 등록한 강의들의 제목 및 간략 정보를 반환합니다."
+    )
+    public ResponseEntity<List <LectureListItemResponse>> dashBoard(@AuthenticationPrincipal CustomUserDetails user){
+        // s현재 로그인한 사용자의 강의 목록 조회
+        List<LectureListItemResponse> userLectureList = memberLectureService.getUserLectureList(user);
+        // 응답 상태코드 200 OK로 반환
+        return ResponseEntity.ok(userLectureList);
+    }
 }

--- a/backend/src/main/java/com/ktnu/AiLectureSummary/controller/MemberLectureController.java
+++ b/backend/src/main/java/com/ktnu/AiLectureSummary/controller/MemberLectureController.java
@@ -5,7 +5,6 @@ import com.ktnu.AiLectureSummary.dto.lecture.LectureListItemResponse;
 import com.ktnu.AiLectureSummary.dto.lecture.LectureResponse;
 import com.ktnu.AiLectureSummary.security.principal.CustomUserDetails;
 import com.ktnu.AiLectureSummary.service.MemberLectureService;
-import com.ktnu.AiLectureSummary.service.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;

--- a/backend/src/main/java/com/ktnu/AiLectureSummary/controller/MemberLectureController.java
+++ b/backend/src/main/java/com/ktnu/AiLectureSummary/controller/MemberLectureController.java
@@ -29,7 +29,7 @@ public class MemberLectureController {
             description = "로그인한 사용자가 등록한 강의들의 제목 및 간략 정보를 반환합니다."
     )
     public ResponseEntity<List <LectureListItemResponse>> dashBoard(@AuthenticationPrincipal CustomUserDetails user){
-        // s현재 로그인한 사용자의 강의 목록 조회
+        // 현재 로그인한 사용자의 강의 목록 조회
         List<LectureListItemResponse> userLectureList = memberLectureService.getUserLectureList(user);
         // 응답 상태코드 200 OK로 반환
         return ResponseEntity.ok(userLectureList);

--- a/backend/src/main/java/com/ktnu/AiLectureSummary/dto/lecture/LectureListItemResponse.java
+++ b/backend/src/main/java/com/ktnu/AiLectureSummary/dto/lecture/LectureListItemResponse.java
@@ -1,0 +1,22 @@
+package com.ktnu.AiLectureSummary.dto.lecture;
+
+import com.ktnu.AiLectureSummary.domain.Lecture;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@AllArgsConstructor
+@Getter
+@Builder
+public class LectureListItemResponse {
+    Long lectureId;
+    String title;
+
+    public static List <LectureListItemResponse> fromList(List <Lecture> lectures){
+        return lectures.stream()
+                .map(lecture -> new LectureListItemResponse(lecture.getId(), lecture.getTitle()))
+                .toList();
+    }
+}

--- a/backend/src/main/java/com/ktnu/AiLectureSummary/service/LectureApplicationService.java
+++ b/backend/src/main/java/com/ktnu/AiLectureSummary/service/LectureApplicationService.java
@@ -11,15 +11,25 @@ import org.springframework.web.multipart.MultipartFile;
 @RequiredArgsConstructor
 @Service
 @Transactional
+
+/**
+ * 사용자의 강의 업로드 요청을 처리하는 애플리케이션 서비스
+ *
+ * 파일을 받아 Lecture 도메인으로 변환하고 저장하며,
+ * 해당 사용자가 업로드한 강의로 기록을 남깁니다.
+ *
+ * 내부적으로 LectureService와 MemberLectureService를 조합하여
+ * 하나의 유스케이스 단위 로직을 처리합니다.
+ */
 public class LectureApplicationService {
     private final LectureService lectureService;
     private final MemberLectureService memberLectureService;
 
     public LectureResponse uploadLecture(CustomUserDetails user, MultipartFile file) {
-        // 1. 강의 처리
+        // 1. 강의 처리 (파일 -> 강의 생성 -> 저장)
         Lecture lecture = lectureService.processLecture(file);
 
-        // 2. 사용자 조회
+        // 2. 사용자와 강의 연결 저장
         memberLectureService.save(user, lecture);
 
         // 3. 응답 반환

--- a/backend/src/main/java/com/ktnu/AiLectureSummary/service/LectureService.java
+++ b/backend/src/main/java/com/ktnu/AiLectureSummary/service/LectureService.java
@@ -151,7 +151,11 @@ public class LectureService {
         }
     }
 
-
+    /**
+     * 사용자가 업로드한 파일이 기대하는 파일형식과 동일한지 검사한다.
+     *
+     * @param file
+     */
     private void validateVideoFile(MultipartFile file) {
         // 파일 확장자는 사용자가 쉽게 변경할 수 있으므로 신뢰할 수 없음
         // MIME 타입(Content-Type)을 기반으로 파일 형식을 검증함

--- a/backend/src/main/java/com/ktnu/AiLectureSummary/service/MemberLectureService.java
+++ b/backend/src/main/java/com/ktnu/AiLectureSummary/service/MemberLectureService.java
@@ -4,24 +4,30 @@ package com.ktnu.AiLectureSummary.service;
 import com.ktnu.AiLectureSummary.domain.Lecture;
 import com.ktnu.AiLectureSummary.domain.Member;
 import com.ktnu.AiLectureSummary.domain.MemberLecture;
+import com.ktnu.AiLectureSummary.dto.lecture.LectureListItemResponse;
 import com.ktnu.AiLectureSummary.repository.MemberLectureRepository;
 import com.ktnu.AiLectureSummary.security.principal.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class MemberLectureService {
     private final MemberLectureRepository memberLectureRepository;
-    private final MemberService memberService;
 
+    /**
+     * 사용자와 강의 간의 소유 관계를 저장합니다.
+     * 이미 해당 관계가 존재하는 경우 중복 저장을 방지합니다.
+     *
+     * @param user 현재 로그인한 사용자 정보     * @param lecture
+     */
     public void save(CustomUserDetails user, Lecture lecture) {
-        Member member = memberService.findById(user.getId());
-
-        if (!memberLectureRepository.existsByMemberAndLecture(member, lecture)) {
+        if (!memberLectureRepository.existsByMemberAndLecture(user.getMember(), lecture)) {
             memberLectureRepository.save(
                     MemberLecture.builder()
-                            .member(member)
+                            .member(user.getMember())
                             .lecture(lecture)
                             .build()
             );
@@ -29,5 +35,22 @@ public class MemberLectureService {
 
     }
 
+    /**
+     * 사용자가 등록한 모든 강의 목록을 조회합니다.
+     * 내부적으로 MemberLecture를 통해 강의 리스트를 추출하고
+     * LectureListItemResponse DTO 형태로 응답할 수 있도록 변환합니다.
+     *
+     * @param user 현재 로그인한 사용자 정보
+     * @return LectureListItemResponse 리스트 (강의 ID + 제목)
+     */
+    public List<LectureListItemResponse> getUserLectureList(CustomUserDetails user) {
 
+        List<MemberLecture> memberLectures = memberLectureRepository.findAllByMember_Id(user.getId());
+
+        List<Lecture> lectures = memberLectures.stream()
+                .map(MemberLecture::getLecture) // MemberLecture -> Lecture
+                .toList();
+
+        return LectureListItemResponse.fromList(lectures);
+    }
 }


### PR DESCRIPTION
- 내 강의 목록 조회 기능 API 구현 (/api/member-lecture/dashboard)
- DTO 추가 LectureListItemResponse
- MemberLectureService 불필요한 로직 삭제 및 리팩토링

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a dashboard endpoint for users to view their associated lectures.
- **Documentation**
  - Enhanced API documentation with detailed descriptions and Swagger annotations.
  - Added comprehensive Javadoc comments to improve clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->