### PR TITLE
feat:getLectureDeatil, WritePersonalNote 기능 구현

### DIFF
--- a/backend/src/main/java/com/ktnu/AiLectureSummary/controller/MemberLectureController.java
+++ b/backend/src/main/java/com/ktnu/AiLectureSummary/controller/MemberLectureController.java
@@ -1,19 +1,20 @@
 package com.ktnu.AiLectureSummary.controller;
 
 
+import com.ktnu.AiLectureSummary.dto.lecture.LectureDetailResponse;
 import com.ktnu.AiLectureSummary.dto.lecture.LectureListItemResponse;
 import com.ktnu.AiLectureSummary.dto.lecture.LectureResponse;
+import com.ktnu.AiLectureSummary.dto.lecture.PersonalNoteRequest;
 import com.ktnu.AiLectureSummary.security.principal.CustomUserDetails;
 import com.ktnu.AiLectureSummary.service.MemberLectureService;
 import com.ktnu.AiLectureSummary.service.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
+import jakarta.transaction.Transactional;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -24,15 +25,57 @@ public class MemberLectureController {
 
     private final MemberLectureService memberLectureService;
 
+
+    /**
+     * 로그인한 사용자가 등록한 강의들의 제목 및 간략 정보를 반환합니다.
+     *
+     * @param user 로그인한 사용자 정보
+     * @return 사용자가 등록한 강의목록과 200 ok 상태 코드
+     */
     @GetMapping("/dashboard")
     @Operation(
             summary = "내 강의 목록 조회",
             description = "로그인한 사용자가 등록한 강의들의 제목 및 간략 정보를 반환합니다."
     )
     public ResponseEntity<List <LectureListItemResponse>> dashBoard(@AuthenticationPrincipal CustomUserDetails user){
-        // s현재 로그인한 사용자의 강의 목록 조회
+        // 현재 로그인한 사용자의 강의 목록 조회
         List<LectureListItemResponse> userLectureList = memberLectureService.getUserLectureList(user);
         // 응답 상태코드 200 OK로 반환
         return ResponseEntity.ok(userLectureList);
+    }
+
+    /**
+     * 로그인한 사용자가 등록한 특정 강의의 전체 요약 내용을 조회합니다. (제목, 원문, AI 요약, 사용자 메모 포함)
+     *
+     * @param user 로그인한 사용자 정보
+     * @param lectureId
+     * @return 사용자가 등록한 강의 상세 정보
+     */
+    @GetMapping("/{lectureId}")
+    @Operation(summary = "내 특정 강의 상세 조희",description = "로그인한 사용자가 등록한 특정 강의의 전체 요약 내용을 조회합니다. (제목, 원문, AI 요약, 사용자 메모 포함)")
+    public ResponseEntity<LectureDetailResponse> getLectureDetail(@AuthenticationPrincipal CustomUserDetails user,@PathVariable Long lectureId){
+        LectureDetailResponse lectureDetailResponse = memberLectureService.getLectureDetail(user, lectureId);
+        return ResponseEntity.ok(lectureDetailResponse);
+    }
+
+
+    /**
+     * 로그인한 사용자가 등록한 특정 강의의 개인 메모를 작성합니다.
+     *
+     * @param user 로그인한 사용자 정보
+     * @param lectureId
+     * @param request
+     * @return 사용자가 등록한 강의 상세 정보
+     */
+    @Transactional
+    @PostMapping("/{lectureId}/my-note")
+    @Operation(summary = "내 특정 강의 개인 메모",description = "로그인한 사용자가 등록한 특정 강의의 개인 메모를 작성합니다.")
+    public ResponseEntity<LectureDetailResponse> writePersonalNote(
+            @AuthenticationPrincipal CustomUserDetails user,
+            @PathVariable Long lectureId, @RequestBody @Valid PersonalNoteRequest request
+    ){
+        LectureDetailResponse lectureDetailResponse = memberLectureService.writePersonalNote(user, lectureId, request.getNote());
+
+        return ResponseEntity.ok(lectureDetailResponse);
     }
 }

--- a/backend/src/main/java/com/ktnu/AiLectureSummary/domain/MemberLecture.java
+++ b/backend/src/main/java/com/ktnu/AiLectureSummary/domain/MemberLecture.java
@@ -50,8 +50,9 @@ public class MemberLecture {
     @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private LocalDateTime enrolledAt;
 
-    // 사용자 개별 메모 저장용 (TEXT 타입)
-    @Column(nullable = true, columnDefinition = "TEXT")
+
+    @Setter(AccessLevel.PUBLIC)
+    @Column(nullable = true, columnDefinition = "TEXT") // 사용자 개별 메모 저장용 (TEXT 타입)
     private String personalNote;
 
 }

--- a/backend/src/main/java/com/ktnu/AiLectureSummary/dto/lecture/LectureDetailResponse.java
+++ b/backend/src/main/java/com/ktnu/AiLectureSummary/dto/lecture/LectureDetailResponse.java
@@ -1,0 +1,27 @@
+package com.ktnu.AiLectureSummary.dto.lecture;
+
+import com.ktnu.AiLectureSummary.domain.Lecture;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class LectureDetailResponse {
+    private Long id;
+    private String title;
+    private String originalText;
+    private String aiSummary;
+    private String personalNote;
+
+    public static LectureDetailResponse from(Lecture lecture,String personalNote){
+        return LectureDetailResponse.builder()
+                .id(lecture.getId())
+                .title(lecture.getTitle())
+                .aiSummary(lecture.getAiSummary())
+                .originalText(lecture.getOriginalText())
+                .personalNote(personalNote)
+                .build();
+    }
+}

--- a/backend/src/main/java/com/ktnu/AiLectureSummary/dto/lecture/PersonalNoteRequest.java
+++ b/backend/src/main/java/com/ktnu/AiLectureSummary/dto/lecture/PersonalNoteRequest.java
@@ -1,0 +1,15 @@
+package com.ktnu.AiLectureSummary.dto.lecture;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class PersonalNoteRequest {
+    @Size(max = 1000, message = "메모는 최대 1000자 까지 입력 가능합니다.")
+    private String note;
+}

--- a/backend/src/main/java/com/ktnu/AiLectureSummary/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/ktnu/AiLectureSummary/exception/GlobalExceptionHandler.java
@@ -152,4 +152,23 @@ public class GlobalExceptionHandler {
                         .build()
         );
     }
+
+    /**
+     * 조회한 강의를 찾을 수 없어 발생한 예외 처리 핸들러
+     *
+     * @param e 강의를 찾을 수 없어 발생한 예외 객체
+     * @return 404 (Not Found) 응답과 함께 상세 에러 메시지 반환
+     */
+    @ExceptionHandler(LectureNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleLectureNotFoundException(LectureNotFoundException e, HttpServletRequest request) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(
+                ErrorResponse.builder()
+                        .error("LECTURE_NOT_FOUND")
+                        .message(e.getMessage())
+                        .status(HttpStatus.NOT_FOUND.value())
+                        .path(request.getRequestURI())
+                        .timestamp(LocalDateTime.now())
+                        .build()
+        );
+    }
 }

--- a/backend/src/main/java/com/ktnu/AiLectureSummary/exception/LectureNotFoundException.java
+++ b/backend/src/main/java/com/ktnu/AiLectureSummary/exception/LectureNotFoundException.java
@@ -1,0 +1,11 @@
+package com.ktnu.AiLectureSummary.exception;
+
+public class LectureNotFoundException extends RuntimeException {
+    public LectureNotFoundException(String message) {
+        super(message);
+    }
+
+    public LectureNotFoundException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/backend/src/main/java/com/ktnu/AiLectureSummary/repository/MemberLectureRepository.java
+++ b/backend/src/main/java/com/ktnu/AiLectureSummary/repository/MemberLectureRepository.java
@@ -12,8 +12,12 @@ import java.util.Optional;
 @Repository
 public interface MemberLectureRepository extends JpaRepository<MemberLecture, Long> {
     Optional<MemberLecture> findByMember_IdAndLecture_Hash(long memberId, String hash); // member.id와 lecture.hash 값으로 이미 등록된 강의인지 확인
+    Optional<MemberLecture> findByMember_IdAndLecture_Id(long memberId, long lectureId); // member.id와 lecture.id로 자신이 등록한 강의가 맞는지 확인
+
+
 
     // 특정 회원이 등록한 모든 강의 목록 조회
     List<MemberLecture> findAllByMember_Id(Long memberId);
     boolean existsByMemberAndLecture(Member member, Lecture lecture);
+
 }

--- a/backend/src/main/java/com/ktnu/AiLectureSummary/service/MemberLectureService.java
+++ b/backend/src/main/java/com/ktnu/AiLectureSummary/service/MemberLectureService.java
@@ -2,11 +2,13 @@ package com.ktnu.AiLectureSummary.service;
 
 
 import com.ktnu.AiLectureSummary.domain.Lecture;
-import com.ktnu.AiLectureSummary.domain.Member;
 import com.ktnu.AiLectureSummary.domain.MemberLecture;
+import com.ktnu.AiLectureSummary.dto.lecture.LectureDetailResponse;
 import com.ktnu.AiLectureSummary.dto.lecture.LectureListItemResponse;
+import com.ktnu.AiLectureSummary.exception.LectureNotFoundException;
 import com.ktnu.AiLectureSummary.repository.MemberLectureRepository;
 import com.ktnu.AiLectureSummary.security.principal.CustomUserDetails;
+import jakarta.validation.constraints.Size;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -52,5 +54,46 @@ public class MemberLectureService {
                 .toList();
 
         return LectureListItemResponse.fromList(lectures);
+    }
+
+    /**
+     * 강의 상세 요약 정보를 가져옵니다.
+     * member.id, lectureId로  사용자가 등록한 강의가 맞나 확인 하고 강의 상세 요약 정보를 반환합니다.
+     *
+     * @param user 현재 로그인한 사용자 정보
+     * @param lectureId
+     * @return
+     */
+    public LectureDetailResponse getLectureDetail(CustomUserDetails user, long lectureId) {
+
+        MemberLecture memberLecture = memberLectureRepository.findByMember_IdAndLecture_Id(user.getId(), lectureId)
+                .orElseThrow(() -> new LectureNotFoundException("해당 강의를 찾을 수 없습니다."));
+
+        return LectureDetailResponse.from(
+                memberLecture.getLecture(),
+                memberLecture.getPersonalNote()
+        );
+
+    }
+
+    /**
+     * 강의에 대한 개인 메모를 작성합니다.
+     * member.id, lectureId로  사용자가 등록한 강의가 맞나 확인 하고, 개인 메모를 저장합니다.
+     *
+     * @param user 현재 로그인한 사용자 정보
+     * @param lectureId
+     * @param note 사용자가 입력한 요약 정보
+     * @return
+     */
+    public LectureDetailResponse writePersonalNote(CustomUserDetails user, Long lectureId, String note) {
+        MemberLecture memberLecture = memberLectureRepository.findByMember_IdAndLecture_Id(user.getId(), lectureId)
+                .orElseThrow(() -> new LectureNotFoundException("해당 강의를 찾을 수 없습니다."));
+
+        memberLecture.setPersonalNote(note);
+
+        return LectureDetailResponse.from(
+                memberLecture.getLecture(),
+                memberLecture.getPersonalNote()
+        );
     }
 }


### PR DESCRIPTION
- **LectureDetailResponse DTO 구현**
    
    → Lecture 정보 + personalNote를 포함한 상세 응답 구조 설계
    
- **내 강의 상세 조회 기능 구현**
    
    → getLectureDetail(CustomUserDetails user, long lectureId)
    
    → 강의 ID로 상세 정보 조회, 개인 메모 포함 응답
    
- **개인 메모 작성 기능 구현**
    
    → writePersonalNote(CustomUserDetails user, Long lectureId, String note)
    
    → 개인 메모 작성/갱신 후 LectureDetailResponse 반환
    
- CR 기능 전반 구현 완료 (Lecture 업로드/조회, 메모 작성 포함)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability for users to view detailed information about their registered lectures, including title, original content, AI-generated summary, and personal notes.
  - Introduced functionality for users to write or update personal notes for each registered lecture.
- **Bug Fixes**
  - Improved error handling with clear messages when a requested lecture is not found.
- **Documentation**
  - Enhanced API documentation with updated comments and JavaDoc for new endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->